### PR TITLE
Ensured helm charts aren't too large.

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,5 +1,21 @@
 # Custom entries
 log.txt
+img/*
+.yarn/*
+.github/*
+.circleci/*
+.git/*
+.eslintignore
+.eslintrc.js
+.firebaserc
+.gitignore
+.prettierrc
+.yarnrc
+babel.config.mjs
+firebase.json
+lerna.json
+package.json
+packages/*
 
 # General files for the project
 pkg/*
@@ -33,9 +49,6 @@ bin/*
 *.un~
 Session.vim
 .netrwhist
-
-# Chart dependencies
-charts/*.tgz
 
 .history
 
@@ -198,9 +211,6 @@ typings/
 
 # Optional REPL history
 .node_repl_history
-
-# Output of 'npm pack'
-*.tgz
 
 # Yarn Integrity file
 .yarn-integrity

--- a/Chart.lock
+++ b/Chart.lock
@@ -18,4 +18,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 15.3.4
 digest: sha256:e866192b50f65ad1873d6ce9bc7b08a3e9c8c472ec12308c09a230b646e27412
-generated: "2022-03-02T18:58:30.450807393-05:00"
+generated: "2022-03-03T14:37:01.239808633-05:00"

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,1 +1,0 @@
-This directory stores helm charts.

--- a/packages/deep-microservice-analysis/.helmignore
+++ b/packages/deep-microservice-analysis/.helmignore
@@ -1,5 +1,9 @@
 # Custom entries
 log.txt
+src/*
+test/*
+Dockerfile
+package.json
 
 # General files for the project
 pkg/*
@@ -33,9 +37,6 @@ bin/*
 *.un~
 Session.vim
 .netrwhist
-
-# Chart dependencies
-charts/*.tgz
 
 .history
 
@@ -198,9 +199,6 @@ typings/
 
 # Optional REPL history
 .node_repl_history
-
-# Output of 'npm pack'
-*.tgz
 
 # Yarn Integrity file
 .yarn-integrity

--- a/packages/deep-microservice-analysis/charts/README.md
+++ b/packages/deep-microservice-analysis/charts/README.md
@@ -1,1 +1,0 @@
-This directory stores helm charts.

--- a/packages/deep-microservice-analysis/src/microservice.mjs
+++ b/packages/deep-microservice-analysis/src/microservice.mjs
@@ -46,7 +46,7 @@ class Microservice {
             },
         });
 
-        const port = process.env.GRAPHQL_PORT;
+        const port = Number(process.env.GRAPHQL_PORT);
         if (!port) {
             throw new Error(`A port at which the application can be accessed is required. Received: ${port}`);
         }

--- a/packages/deep-microservice-analysis/templates/environment.yaml
+++ b/packages/deep-microservice-analysis/templates/environment.yaml
@@ -4,6 +4,6 @@ metadata:
     name: {{ printf "%s-deep-microservice-analysis-config-map" (.Release.Name) | quote }}
     namespace: {{ .Release.Namespace | quote }}
 data:
-    GRAPHQL_PORT: {{ printf "%d" (required "A valid port at which the application can be accessed is required" .Values.graphql.port) | quote }}
+    GRAPHQL_PORT: {{ required "A valid port at which the application can be accessed is required" .Values.graphql.port | quote }}
     GRAPHQL_PATH: {{ required "A valid path at which the application can be accessed is required (i.e, /graphql)" .Values.graphql.path | quote}}
     NODE_ENV: {{ required "A valid node environment is required" .Values.global.nodeEnv | quote}}

--- a/packages/deep-microservice-analysis/values.yaml
+++ b/packages/deep-microservice-analysis/values.yaml
@@ -3,12 +3,12 @@
     kafka:
       secretName: ""
       host: ""
-      port: 9092
+      port: "9092"
     docker:
       secretName: ""
 
   graphql:
-    port: 4001
+    port: "4001"
     path: "/graphql"
 
   replicas: 1

--- a/packages/deep-microservice-collection/.helmignore
+++ b/packages/deep-microservice-collection/.helmignore
@@ -1,5 +1,10 @@
 # Custom entries
 log.txt
+src/*
+test/*
+Dockerfile
+package.json
+collect-data/*
 
 # General files for the project
 pkg/*
@@ -33,9 +38,6 @@ bin/*
 *.un~
 Session.vim
 .netrwhist
-
-# Chart dependencies
-charts/*.tgz
 
 .history
 
@@ -198,9 +200,6 @@ typings/
 
 # Optional REPL history
 .node_repl_history
-
-# Output of 'npm pack'
-*.tgz
 
 # Yarn Integrity file
 .yarn-integrity

--- a/packages/deep-microservice-collection/charts/README.md
+++ b/packages/deep-microservice-collection/charts/README.md
@@ -1,1 +1,0 @@
-This directory stores helm charts.

--- a/packages/deep-microservice-collection/src/index.mjs
+++ b/packages/deep-microservice-collection/src/index.mjs
@@ -98,7 +98,7 @@ const startApolloServer = async () => {
       },
   });
 
-  const port = process.env.GRAPHQL_PORT;
+  const port = Number(process.env.GRAPHQL_PORT);
   if (!port) {
       throw new Error(`A port at which the application can be accessed is required. Received: ${port}`);
   }

--- a/packages/deep-microservice-collection/templates/environment.yaml
+++ b/packages/deep-microservice-collection/templates/environment.yaml
@@ -4,7 +4,7 @@ metadata:
     name: {{ printf "%s-deep-microservice-collection-config-map" .Release.Name | quote }}
     namespace: {{ .Release.Namespace | quote }}
 data:
-    GRAPHQL_PORT: {{ printf "%d" (required "A valid port at which the application can be accessed is required" .Values.graphql.port) | quote }}
+    GRAPHQL_PORT: {{ required "A valid port at which the application can be accessed is required" .Values.graphql.port | quote }}
     GRAPHQL_PATH: {{ required "A valid path at which the application can be accessed is required (i.e, /graphql)" .Values.graphql.path | quote}}
     NAMESPACE: {{ .Release.Namespace | quote }}
     HELM_RELEASE_NAME: {{ .Release.Name | quote }}

--- a/packages/deep-microservice-collection/values.yaml
+++ b/packages/deep-microservice-collection/values.yaml
@@ -3,14 +3,14 @@
     kafka:
       secretName: ""
       host: ""
-      port: 9092
+      port: "9092"
     docker:
       secretName: ""
 
   replicas: 1
 
   graphql:
-    port: 4002
+    port: "4002"
     path: "/graphql"
 
   collectionmongodb:

--- a/packages/deep-microservice-configuration/.helmignore
+++ b/packages/deep-microservice-configuration/.helmignore
@@ -1,5 +1,9 @@
 # Custom entries
 log.txt
+src/*
+test/*
+Dockerfile
+package.json
 
 # General files for the project
 pkg/*
@@ -33,9 +37,6 @@ bin/*
 *.un~
 Session.vim
 .netrwhist
-
-# Chart dependencies
-charts/*.tgz
 
 .history
 
@@ -198,9 +199,6 @@ typings/
 
 # Optional REPL history
 .node_repl_history
-
-# Output of 'npm pack'
-*.tgz
 
 # Yarn Integrity file
 .yarn-integrity

--- a/packages/deep-microservice-configuration/charts/README.md
+++ b/packages/deep-microservice-configuration/charts/README.md
@@ -1,1 +1,0 @@
-This directory stores helm charts.

--- a/packages/deep-microservice-configuration/src/index.mjs
+++ b/packages/deep-microservice-configuration/src/index.mjs
@@ -61,9 +61,9 @@ const startApolloServer = async () => {
       throw new Error(`A path at which the application can be accessed is required (i.e, /graphql). Received: ${path}`);
   }
 
-  this._logger.debug(`Applying middleware.`);
-  this._apolloServer.applyMiddleware({
-      app: this._expressApp,
+  logger.debug(`Applying middleware.`);
+  server.applyMiddleware({
+      app,
       path,
       cors: {
           origin: allowedOrigins,
@@ -72,7 +72,7 @@ const startApolloServer = async () => {
       },
   });
 
-  const port = process.env.GRAPHQL_PORT;
+  const port = Number(process.env.GRAPHQL_PORT);
   if (!port) {
       throw new Error(`A port at which the application can be accessed is required. Received: ${port}`);
   }

--- a/packages/deep-microservice-configuration/templates/environment.yaml
+++ b/packages/deep-microservice-configuration/templates/environment.yaml
@@ -4,6 +4,6 @@ metadata:
     name: {{ printf "%s-deep-microservice-configuration-config-map" .Release.Name | quote }}
     namespace: {{ .Release.Namespace | quote }}
 data:
-    GRAPHQL_PORT: {{ printf "%d" (required "A valid port at which the application can be accessed is required" .Values.graphql.port) | quote }}
+    GRAPHQL_PORT: {{ required "A valid port at which the application can be accessed is required" .Values.graphql.port | quote }}
     GRAPHQL_PATH: {{ required "A valid path at which the application can be accessed is required (i.e, /graphql)" .Values.graphql.path | quote}}
     NODE_ENV: {{ required "A valid node environment is required" .Values.global.nodeEnv | quote}}

--- a/packages/deep-microservice-gateway/.helmignore
+++ b/packages/deep-microservice-gateway/.helmignore
@@ -1,5 +1,9 @@
 # Custom entries
 log.txt
+src/*
+test/*
+Dockerfile
+package.json
 
 # General files for the project
 pkg/*
@@ -33,9 +37,6 @@ bin/*
 *.un~
 Session.vim
 .netrwhist
-
-# Chart dependencies
-charts/*.tgz
 
 .history
 
@@ -198,9 +199,6 @@ typings/
 
 # Optional REPL history
 .node_repl_history
-
-# Output of 'npm pack'
-*.tgz
 
 # Yarn Integrity file
 .yarn-integrity

--- a/packages/deep-microservice-gateway/charts/README.md
+++ b/packages/deep-microservice-gateway/charts/README.md
@@ -1,1 +1,0 @@
-This directory stores helm charts.

--- a/packages/deep-microservice-gateway/src/index.mjs
+++ b/packages/deep-microservice-gateway/src/index.mjs
@@ -112,7 +112,7 @@ const startGatewayService = async () => {
       },
   });
 
-  const port = process.env.GRAPHQL_PORT;
+  const port = Number(process.env.GRAPHQL_PORT);
   if (!port) {
       throw new Error(`A port at which the application can be accessed is required. Received: ${port}`);
   }

--- a/packages/deep-microservice-gateway/templates/environment.yaml
+++ b/packages/deep-microservice-gateway/templates/environment.yaml
@@ -4,6 +4,6 @@ metadata:
     name: {{ printf "%s-deep-microservice-gateway-config-map" .Release.Name | quote }}
     namespace: {{ .Release.Namespace | quote }}
 data:
-    GRAPHQL_PORT: {{ printf "%d" (required "A valid port at which the application can be accessed is required" .Values.graphql.port) | quote }}
+    GRAPHQL_PORT: {{ required "A valid port at which the application can be accessed is required" .Values.graphql.port | quote }}
     GRAPHQL_PATH: {{ required "A valid path at which the application can be accessed is required (i.e, /graphql)" .Values.graphql.path | quote}}
     NODE_ENV: {{ required "A valid node environment is required" .Values.global.nodeEnv | quote}}

--- a/packages/deep-microservice-subscription/.helmignore
+++ b/packages/deep-microservice-subscription/.helmignore
@@ -1,5 +1,9 @@
 # Custom entries
 log.txt
+src/*
+test/*
+Dockerfile
+package.json
 
 # General files for the project
 pkg/*
@@ -33,9 +37,6 @@ bin/*
 *.un~
 Session.vim
 .netrwhist
-
-# Chart dependencies
-charts/*.tgz
 
 .history
 
@@ -198,9 +199,6 @@ typings/
 
 # Optional REPL history
 .node_repl_history
-
-# Output of 'npm pack'
-*.tgz
 
 # Yarn Integrity file
 .yarn-integrity

--- a/packages/deep-microservice-subscription/charts/README.md
+++ b/packages/deep-microservice-subscription/charts/README.md
@@ -1,1 +1,0 @@
-This directory stores helm charts.

--- a/packages/deep-microservice-subscription/src/index.mjs
+++ b/packages/deep-microservice-subscription/src/index.mjs
@@ -216,7 +216,7 @@ const startApolloServer = async () => {
     },
   }, webSocketServer);
 
-  const port = process.env.GRAPHQL_PORT;
+  const port = Number(process.env.GRAPHQL_PORT);
   if (!port) {
       throw new Error(`A port at which the application can be accessed is required. Received: ${port}`);
   }

--- a/packages/deep-microservice-subscription/templates/environment.yaml
+++ b/packages/deep-microservice-subscription/templates/environment.yaml
@@ -4,6 +4,6 @@ metadata:
     name: {{ printf "%s-deep-microservice-subscription-environment" .Release.Name | quote }}
     namespace: {{ .Release.Namespace | quote }}
 data:
-    GRAPHQL_PORT: {{ printf "%d" (required "A valid port at which the application can be accessed is required" .Values.graphql.port) | quote }}
+    GRAPHQL_PORT: {{ required "A valid port at which the application can be accessed is required" .Values.graphql.port | quote }}
     GRAPHQL_PATH: {{ required "A valid path at which the application can be accessed is required (i.e, /graphql)" .Values.graphql.path | quote}}
     NODE_ENV: {{ required "A valid node environment is required" .Values.global.nodeEnv | quote}}

--- a/packages/deep-microservice-subscription/values.yaml
+++ b/packages/deep-microservice-subscription/values.yaml
@@ -8,14 +8,14 @@
     kafka:
       secretName: ""
       host: ""
-      port: 9092
+      port: "9092"
     docker:
       secretName: ""
 
   replicas: 1
 
   graphql:
-    port: 4004
+    port: "4004"
     path: "/graphql"
 
   microservice:

--- a/templates/kafka-secret.yaml
+++ b/templates/kafka-secret.yaml
@@ -5,4 +5,4 @@ metadata:
     namespace: {{ .Release.Namespace | quote }}
 data:
     PREDECOS_KAFKA_HOST: {{ printf "%s-kafka.%s.svc.cluster.local" .Release.Name .Release.Namespace | b64enc | quote}}
-    PREDECOS_KAFKA_PORT: {{ printf "%d" (required "A valid kafka port is required." .Values.global.kafka.port) | b64enc }}
+    PREDECOS_KAFKA_PORT: {{ printf "%s" (required "A valid kafka port is required." .Values.global.kafka.port) | b64enc }}

--- a/values.yaml
+++ b/values.yaml
@@ -8,19 +8,19 @@
         secretName: "deep-microservice-auth-secret"
     kafka:
       secretName: "deep-kafka-secret"
-      port: 9092
+      port: "9092"
     docker:
       secretName: ""
 
   analysis:
     graphql:
-      port: 4001
+      port: "4001"
       path: "/graphql"
     replicas: 1
 
   collection:
     graphql:
-      port: 4002
+      port: "4002"
       path: "/graphql"
     replicas: 1
     twitter:
@@ -28,13 +28,13 @@
 
   configuration:
     graphql:
-      port: 4003
+      port: "4003"
       path: "/graphql"
     replicas: 1
 
   gateway:
     graphql:
-      port: 4000
+      port: "4000"
       path: "/graphql"
     replicas: 1
     service:
@@ -42,7 +42,7 @@
 
   subscription:
     graphql:
-      port: 4004
+      port: "4004"
       path: "/graphql"
     replicas: 1
     service:


### PR DESCRIPTION
- Modified microservices to avoid issue with helm int -> float conversions.
- Modified values.yaml in each microservice to include kafka.port and graphql.port as strings, modified the same in the root project.