### PR TITLE
Reintroduced server listen to configuration and increased timeout during helm install to 20 minutes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
             release-name: "v1"
             values-to-override: "gateway.service.certificateId=2b25c4eb-828e-4e9c-8c55-9f3deb85e331,subscription.service.certificateId=5fba8346-80ac-44a4-8521-3f7ab7dd3153,auth.audience=$PREDECOS_AUTH_AUDIENCE,auth.jwksUri=$PREDECOS_AUTH_JWKS_URI,auth.issuer=$PREDECOS_AUTH_ISSUER,collection.twitter.bearer=$PREDECOS_TWITTER_BEARER,replicas=1,global.docker.secretName=docker-secret,global.nodeEnv=$NODE_ENV"
             update-repositories: true
-            timeout: "600s"
+            timeout: "1200s"
             wait: true
 
 

--- a/packages/deep-microservice-configuration/src/index.mjs
+++ b/packages/deep-microservice-configuration/src/index.mjs
@@ -77,6 +77,8 @@ const startApolloServer = async () => {
       throw new Error(`A port at which the application can be accessed is required. Received: ${port}`);
   }
 
+  await new Promise((resolve) => app.listen({port}, resolve));
+
   logger.info(
     `🚀 Server ready at http://${getPublicIP()}:${port}${server.graphqlPath}`
   );


### PR DESCRIPTION
part of https://github.com/ThinkDeepTech/thinkdeep/issues/147
part of https://github.com/ThinkDeepTech/thinkdeep/issues/286